### PR TITLE
feat: proxy more config options for rdkafka

### DIFF
--- a/.changeset/lucky-pets-play.md
+++ b/.changeset/lucky-pets-play.md
@@ -1,0 +1,5 @@
+---
+"effect-kafka": patch
+---
+
+proxy more config options for rdkafka

--- a/src/Consumer.ts
+++ b/src/Consumer.ts
@@ -50,7 +50,66 @@ export declare namespace Consumer {
   /**
    * @since 0.2.0
    */
-  export interface ConsumerOptions extends KafkaJS.ConsumerConfig {}
+  export interface ConsumerOptions {
+    /**
+     * Client group id string. All clients sharing the same group.id belong to the same group.
+     */
+    groupId: string;
+    metadataMaxAge?: number;
+    sessionTimeout?: number;
+    rebalanceTimeout?: number;
+    heartbeatInterval?: number;
+    /**
+     * Initial maximum number of bytes per topic+partition to request when fetching messages from the broker. If the client encounters a message larger than this value it will gradually try to increase it until the entire message can be fetched.
+     * In other words, it determines how many bytes can be fetched in one request from a single partition. There is a change in semantics, this size grows dynamically if a single message larger than this is encountered, and the client does not get stuck.
+     *
+     * @default 1048576
+     */
+    maxBytesPerPartition?: number;
+    /**
+     * Minimum number of bytes the broker responds with. If fetch.wait.max.ms expires the accumulated data will be sent to the client regardless of this setting.
+     *
+     * @default 1
+     */
+    minBytes?: number;
+    /**
+     * Maximum amount of data the broker shall return for a Fetch request. Messages are fetched in batches by the consumer and if the first message batch in the first non-empty partition of the Fetch request is larger than this value, then the message batch will still be returned to ensure the consumer can make progress. The maximum message batch size accepted by the broker is defined via `message.max.bytes` (broker config) or `max.message.bytes` (broker topic config). `fetch.max.bytes` is automatically adjusted upwards to be at least `message.max.bytes` (consumer config).
+     *
+     * @default 52428800
+     */
+    maxBytes?: number;
+    maxWaitTimeInMs?: number;
+    retry?: KafkaJS.RetryOptions;
+    logLevel?: KafkaJS.logLevel;
+    logger?: KafkaJS.Logger;
+    allowAutoTopicCreation?: boolean;
+    /**
+     *  If true, consumer will read transactional messages which have not been committed.
+     *
+     * @default false
+     */
+    readUncommitted?: boolean;
+    /**
+     * If there is initial offset in offset store or the desired offset is out of range, and this is true, we consume the earliest possible offset.  **This is set on a per-consumer level, not on a per `subscribe` level**.
+     *
+     * @default false
+     */
+    fromBeginning?: boolean;
+    /**
+     * Automatically and periodically commit offsets in the background. Note: setting this to false does not prevent the consumer from fetching previously committed start offsets. To circumvent this behavior set specific start offsets per partition in the call to assign().
+     *
+     * @default true
+     */
+    autoCommit?: boolean;
+    /**
+     * The frequency in milliseconds that the consumer offsets are committed (written) to offset storage. (0 = disable). This setting is used by the high-level consumer.
+     *
+     * @default 5000
+     */
+    autoCommitInterval?: number;
+    partitionAssigners?: KafkaJS.PartitionAssigners[];
+    partitionAssignors?: KafkaJS.PartitionAssignors[];
+  }
 }
 
 /**

--- a/src/Consumer.ts
+++ b/src/Consumer.ts
@@ -55,9 +55,29 @@ export declare namespace Consumer {
      * Client group id string. All clients sharing the same group.id belong to the same group.
      */
     groupId: string;
+    /**
+     * Period of time in milliseconds at which topic and broker metadata is refreshed in order to proactively discover any new brokers, topics, partitions or partition leader changes. Use -1 to disable the intervalled refresh (not recommended). If there are no locally referenced topics (no topic objects created, no messages produced, no subscription or no assignment) then only the broker list will be refreshed every interval but no more often than every 10s.
+     *
+     * @default 300000
+     */
     metadataMaxAge?: number;
+    /**
+     * Client group session and failure detection timeout. The consumer sends periodic heartbeats (heartbeat.interval.ms) to indicate its liveness to the broker. If no hearts are received by the broker for a group member within the session timeout, the broker will remove the consumer from the group and trigger a rebalance. The allowed range is configured with the **broker** configuration properties `group.min.session.timeout.ms` and `group.max.session.timeout.ms`. Also see `max.poll.interval.ms`.
+     *
+     * @default 30000
+     */
     sessionTimeout?: number;
+    /**
+     * Maximum allowed time between calls to consume messages (e.g., rd_kafka_consumer_poll()) for high-level consumers. If this interval is exceeded the consumer is considered failed and the group will rebalance in order to reassign the partitions to another consumer group member. Warning: Offset commits may be not possible at this point. Note: It is recommended to set `enable.auto.offset.store=false` for long-time processing applications and then explicitly store offsets (using offsets_store()) *after* message processing, to make sure offsets are not auto-committed prior to processing has finished. The interval is checked two times per second. See KIP-62 for more information.
+     *
+     * @default 300000
+     */
     rebalanceTimeout?: number;
+    /**
+     * Group session keepalive heartbeat interval.
+     *
+     * @default 3000
+     */
     heartbeatInterval?: number;
     /**
      * Initial maximum number of bytes per topic+partition to request when fetching messages from the broker. If the client encounters a message larger than this value it will gradually try to increase it until the entire message can be fetched.
@@ -78,10 +98,18 @@ export declare namespace Consumer {
      * @default 52428800
      */
     maxBytes?: number;
+    /**
+     * Maximum time the broker may wait to fill the Fetch response with fetch.min.bytes of messages.
+     *
+     * @default 5000
+     */
     maxWaitTimeInMs?: number;
     retry?: KafkaJS.RetryOptions;
-    logLevel?: KafkaJS.logLevel;
-    logger?: KafkaJS.Logger;
+    /**
+     * Allow automatic topic creation on the broker when subscribing to or assigning non-existent topics.
+     *
+     * @default true
+     */
     allowAutoTopicCreation?: boolean;
     /**
      *  If true, consumer will read transactional messages which have not been committed.
@@ -107,8 +135,12 @@ export declare namespace Consumer {
      * @default 5000
      */
     autoCommitInterval?: number;
+    /**
+     * The name of one or more partition assignment strategies. The elected group leader will use a strategy supported by all members of the group to assign partitions to group members. If there is more than one eligible strategy, preference is determined by the order of this list (strategies earlier in the list have higher priority). Cooperative and non-cooperative (eager) strategies must not be mixed. Available strategies: range, roundrobin, cooperative-sticky.
+     *
+     * @default roundrobin
+     */
     partitionAssigners?: KafkaJS.PartitionAssigners[];
-    partitionAssignors?: KafkaJS.PartitionAssignors[];
   }
 }
 

--- a/src/Producer.ts
+++ b/src/Producer.ts
@@ -40,7 +40,87 @@ export declare namespace Producer {
   /**
    * @since 0.2.0
    */
-  export type ProducerOptions = KafkaJS.ProducerConfig;
+  export interface ProducerOptions {
+    metadataMaxAge?: number;
+    /**
+     * Allow automatic topic creation on the broker when subscribing to or assigning non-existent topics. The broker must also be configured with `auto.create.topics.enable=true` for this configuration to take effect. Note: the default value (true) for the producer is different from the default value (false) for the consumer. Further, the consumer default value is different from the Java consumer (true), and this property is not supported by the Java producer. Requires broker version >= 0.11.0.0, for older broker versions only the broker configuration applies.
+     *
+     * @default false
+     */
+    allowAutoTopicCreation?: boolean;
+    /**
+     * When set to `true`, the producer will ensure that messages are successfully produced exactly once and in the original produce order. The following configuration properties are adjusted automatically (if not modified by the user) when idempotence is enabled: `max.in.flight.requests.per.connection=5` (must be less than or equal to 5), `retries=INT32_MAX` (must be greater than 0), `acks=all`, `queuing.strategy=fifo`. Producer instantation will fail if user-supplied configuration is incompatible.
+     *
+     * @default false
+     */
+    idempotent?: boolean;
+    transactionalId?: string;
+    transactionTimeout?: number;
+    maxInFlightRequests?: number;
+    acks?: number;
+    compression?: KafkaJS.CompressionTypes;
+    timeout?: number;
+    retry?: KafkaJS.RetryOptions;
+    logLevel?: KafkaJS.logLevel;
+    logger?: KafkaJS.Logger;
+
+    // RdKafka specific options
+    /**
+     * Partitioner: `random` - random distribution, `consistent` - CRC32 hash of key (Empty and NULL keys are mapped to single partition), `consistent_random` - CRC32 hash of key (Empty and NULL keys are randomly partitioned), `murmur2` - Java Producer compatible Murmur2 hash of key (NULL keys are mapped to single partition), `murmur2_random` - Java Producer compatible Murmur2 hash of key (NULL keys are randomly partitioned. This is functionally equivalent to the default partitioner in the Java Producer.), `fnv1a` - FNV-1a hash of key (NULL keys are mapped to single partition), `fnv1a_random` - FNV-1a hash of key (NULL keys are randomly partitioned).
+     *
+     * @default murmur2_random
+     */
+    partitioner?:
+      | "random"
+      | "consistent_random"
+      | "consistent"
+      | "murmur2"
+      | "murmur2_random"
+      | "fnv1a"
+      | "fnv1a_random";
+    queueBuffering?: {
+      /**
+       * Maximum number of messages allowed on the producer queue. This queue is shared by all topics and partitions. A value of 0 disables this limit.
+       *
+       * @default 100000
+       */
+      maxMessages?: number;
+      /**
+       * Maximum total message size sum allowed on the producer queue. This queue is shared by all topics and partitions. This property has higher priority than `queueBuffering.maxMessages`.
+       *
+       * @default 1048576
+       */
+      maxKbytes?: number;
+      /**
+       * Delay in milliseconds to wait for messages in the producer queue to accumulate before constructing message batches to transmit to brokers. A higher value allows larger and more effective (less overhead, improved compression) batches of messages to accumulate at the expense of increased message delivery latency.
+       *
+       * @default 5
+       */
+      maxMs?: number;
+    };
+    batching?: {
+      /**
+       * Maximum number of messages batched in one MessageSet. The total MessageSet size is also limited by `batching.maxBytes` and `message.max.bytes`.
+       *
+       * @default 10000
+       */
+      maxMessages?: number;
+      /**
+       * Maximum size (in bytes) of all messages batched in one MessageSet, including protocol framing overhead. This limit is applied after the first message has been added to the batch, regardless of the first message's size, this is to ensure that messages that exceed batch.size are produced. The total MessageSet size is also limited by `batching.maxMessages` and `message.max.bytes`.
+       *
+       * @default 1000000
+       */
+      maxBytes?: number;
+    };
+    stickyPartitioning?: {
+      /**
+       * Delay in milliseconds to wait to assign new sticky partitions for each topic. By default, set to double the time of `queueBuffering.maxMs`. To disable sticky behavior, set to 0. This behavior affects messages with the key NULL in all cases, and messages with key lengths of zero when the consistent_random partitioner is in use. These messages would otherwise be assigned randomly. A higher value allows for more effective batching of these messages.
+       *
+       * @default 2 * queueBuffering.maxMs
+       */
+      lingerMs?: number;
+    };
+  }
 
   /**
    * @since 0.2.0

--- a/src/Producer.ts
+++ b/src/Producer.ts
@@ -41,6 +41,11 @@ export declare namespace Producer {
    * @since 0.2.0
    */
   export interface ProducerOptions {
+    /**
+     * Period of time in milliseconds at which topic and broker metadata is refreshed in order to proactively discover any new brokers, topics, partitions or partition leader changes. Use -1 to disable the intervalled refresh (not recommended). If there are no locally referenced topics (no topic objects created, no messages produced, no subscription or no assignment) then only the broker list will be refreshed every interval but no more often than every 10s.
+     *
+     * @default 300000
+     */
     metadataMaxAge?: number;
     /**
      * Allow automatic topic creation on the broker when subscribing to or assigning non-existent topics. The broker must also be configured with `auto.create.topics.enable=true` for this configuration to take effect. Note: the default value (true) for the producer is different from the default value (false) for the consumer. Further, the consumer default value is different from the Java consumer (true), and this property is not supported by the Java producer. Requires broker version >= 0.11.0.0, for older broker versions only the broker configuration applies.
@@ -54,15 +59,42 @@ export declare namespace Producer {
      * @default false
      */
     idempotent?: boolean;
+    /**
+     * Enables the transactional producer. The transactional.id is used to identify the same transactional producer instance across process restarts. It allows the producer to guarantee that transactions corresponding to earlier instances of the same producer have been finalized prior to starting any new transactions, and that any zombie instances are fenced off. If no transactional.id is provided, then the producer is limited to idempotent delivery (if enable.idempotence is set). Requires broker version >= 0.11.0.
+     */
     transactionalId?: string;
+    /**
+     * The maximum amount of time in milliseconds that the transaction coordinator will wait for a transaction status update from the producer before proactively aborting the ongoing transaction. If this value is larger than the `transaction.max.timeout.ms` setting in the broker, the init_transactions() call will fail with ERR_INVALID_TRANSACTION_TIMEOUT. The transaction timeout automatically adjusts `message.timeout.ms` and `socket.timeout.ms`, unless explicitly configured in which case they must not exceed the transaction timeout (`socket.timeout.ms` must be at least 100ms lower than `transaction.timeout.ms`). This is also the default timeout value if no timeout (-1) is supplied to the transactional API methods.
+     *
+     * @default 60000
+     */
     transactionTimeout?: number;
+    /**
+     * Maximum number of in-flight requests per broker connection. This is a generic property applied to all broker communication, however it is primarily relevant to produce requests. In particular, note that other mechanisms limit the number of outstanding consumer fetch request per broker to one.
+     *
+     * @default 1000000
+     */
     maxInFlightRequests?: number;
+    /**
+     * This field indicates the number of acknowledgements the leader broker must receive from ISR brokers before responding to the request: *0*=Broker does not send any response/ack to client, *-1* or *all*=Broker will block until message is committed by all in sync replicas (ISRs). If there are less than `min.insync.replicas` (broker configuration) in the ISR set the produce request will fail.
+     * The number of required acks before a Produce succeeds. **This is set on a per-producer level, not on a per `send` level**. -1 denotes it will wait for all brokers in the in-sync replica set.
+     *
+     * @default -1
+     */
     acks?: number;
+    /**
+     * compression codec to use for compressing message sets. This is the default value for all topics, may be overridden by the topic configuration property `compression.codec`.
+     *
+     * @default none
+     */
     compression?: KafkaJS.CompressionTypes;
+    /**
+     * The ack timeout of the producer request in milliseconds. This value is only enforced by the broker and relies on `acks` being != 0.
+     *
+     * @default 30000
+     */
     timeout?: number;
     retry?: KafkaJS.RetryOptions;
-    logLevel?: KafkaJS.logLevel;
-    logger?: KafkaJS.Logger;
 
     // RdKafka specific options
     /**

--- a/src/internal/confluentRdKafkaInstance.ts
+++ b/src/internal/confluentRdKafkaInstance.ts
@@ -6,6 +6,7 @@ import type {
   Metadata,
   MetadataOptions,
   ProducerGlobalConfig,
+  ProducerTopicConfig,
   SubscribeTopicList,
 } from "@confluentinc/kafka-javascript";
 import { CODES, KafkaConsumer, Producer as KafkaProducer } from "@confluentinc/kafka-javascript";
@@ -120,12 +121,12 @@ export const consume = (consumer: KafkaConsumer, config: { eachMessage: Consumer
   );
 
 /** @internal */
-export const connectProducerScoped = ({
-  logger,
-  ...config
-}: ProducerConfig): Effect.Effect<KafkaProducer, Error.ConnectionException, Scope.Scope> =>
+export const connectProducerScoped = (
+  { logger, ...config }: ProducerConfig,
+  topicConfig?: ProducerTopicConfig,
+): Effect.Effect<KafkaProducer, Error.ConnectionException, Scope.Scope> =>
   Effect.acquireRelease(
-    Effect.sync(() => new KafkaProducer(config)).pipe(
+    Effect.sync(() => new KafkaProducer(config, topicConfig)).pipe(
       Effect.tap((p) => p.on("event.log", logger)),
       Effect.tap((p) => connect(p)),
       Effect.tap(() => Effect.logInfo("Producer connected", { timestamp: new Date().toISOString() })),

--- a/src/internal/confluentRdKafkaInstance.ts
+++ b/src/internal/confluentRdKafkaInstance.ts
@@ -31,10 +31,10 @@ export type LoggingConfig = {
 };
 
 /** @internal */
-export type ProducerConfig = ProducerGlobalConfig & LoggingConfig;
+export type ProducerConfig = ProducerGlobalConfig & ProducerTopicConfig & LoggingConfig;
 
 /** @internal */
-export type ConsumerConfig = ConsumerGlobalConfig & LoggingConfig;
+export type ConsumerConfig = ConsumerGlobalConfig & ConsumerTopicConfig & LoggingConfig;
 
 const tracingFacs = [
   "APIVERSION",
@@ -121,12 +121,12 @@ export const consume = (consumer: KafkaConsumer, config: { eachMessage: Consumer
   );
 
 /** @internal */
-export const connectProducerScoped = (
-  { logger, ...config }: ProducerConfig,
-  topicConfig?: ProducerTopicConfig,
-): Effect.Effect<KafkaProducer, Error.ConnectionException, Scope.Scope> =>
+export const connectProducerScoped = ({
+  logger,
+  ...config
+}: ProducerConfig): Effect.Effect<KafkaProducer, Error.ConnectionException, Scope.Scope> =>
   Effect.acquireRelease(
-    Effect.sync(() => new KafkaProducer(config, topicConfig)).pipe(
+    Effect.sync(() => new KafkaProducer(config)).pipe(
       Effect.tap((p) => p.on("event.log", logger)),
       Effect.tap((p) => connect(p)),
       Effect.tap(() => Effect.logInfo("Producer connected", { timestamp: new Date().toISOString() })),
@@ -144,12 +144,12 @@ export const connectProducerScoped = (
   );
 
 /** @internal */
-export const connectConsumerScoped = (
-  { logger, ...config }: ConsumerConfig,
-  topicConfig?: ConsumerTopicConfig,
-): Effect.Effect<KafkaConsumer, Error.ConnectionException, Scope.Scope> =>
+export const connectConsumerScoped = ({
+  logger,
+  ...config
+}: ConsumerConfig): Effect.Effect<KafkaConsumer, Error.ConnectionException, Scope.Scope> =>
   Effect.acquireRelease(
-    Effect.sync(() => new KafkaConsumer(config, topicConfig)).pipe(
+    Effect.sync(() => new KafkaConsumer(config)).pipe(
       Effect.tap((p) => p.on("event.log", logger)),
       Effect.tap((c) => connect(c)),
       Effect.tap(() => Effect.logInfo("Consumer connected", { timestamp: new Date().toISOString() })),


### PR DESCRIPTION
closes #16 

here is the way to define those particular options:
```ts
import { NodeRuntime } from "@effect/platform-node";
import { Effect, Logger, LogLevel } from "effect";
import { ConfluentRdKafkaInstance, Producer } from "../src";

const program = Producer.sendScoped({
  topic: "test-topic",
  messages: [{ value: "Hello, effect-kafka user!" }, { value: "How are you, effect-kafka user?" }],
}).pipe(
  Producer.withProducerOptions({
    idempotent: false,
    partitioner: "consistent_random",
    queueBuffering: {
      maxMessages: 1000000,
      maxKbytes: 1048576,
      maxMs: 100,
    },
    batching: {
      maxMessages: 100000,
      maxBytes: 4194304,
    },
    stickyPartitioning: {
      lingerMs: 25,
    },
  }),
);

const KafkaLive = ConfluentRdKafkaInstance.layer({
  "metadata.broker.list": "localhost:19092",
  // "fetch.max.bytes": 4194304, // ConsumerOptions.maxBytes
  // "max.partition.fetch.bytes": 1048576, // ConsumerOptions.maxBytesPerPartition
  // "queue.buffering.max.kbytes": 1048576, // ProducerOptions.queueBuffering.maxKbytes
  // "queue.buffering.max.messages": 1000000, // ProducerOptions.queueBuffering.maxMessages
  "message.max.bytes": 4194304,
  // "batch.size": "4194304", // ProducerOptions.batching.maxBytes
  // "batch.num.messages": "100000", // ProducerOptions.batching.maxMessages
  // "linger.ms": "100", // ProducerOptions.queueBuffering.maxMs
  // "sticky.partitioning.linger.ms": "25", // ProducerOptions.stickyPartitioning.lingerMs
  // "enable.idempotence": "false", // ProducerOptions.idempotent
  "max.in.flight.requests.per.connection": 1000000,
  // "partitioner": "consistent_random", // ProducerOptions.partitioner
});
const MainLive = Effect.scoped(program).pipe(Effect.provide(KafkaLive), Logger.withMinimumLogLevel(LogLevel.Debug));

NodeRuntime.runMain(MainLive);
```